### PR TITLE
Improve performance of PacketBuffer class by using a List<>.

### DIFF
--- a/Orbipacket.Library/Cobs.cs
+++ b/Orbipacket.Library/Cobs.cs
@@ -27,7 +27,7 @@ namespace Orbipacket.Library
         /// </summary>
         /// <param name="Input">An array up to 254 bytes in length</param>
         /// <returns>Returns the encoded input</returns>
-        public static IEnumerable<byte> Encode(IEnumerable<byte> Input)
+        public static IEnumerable<byte>? Encode(IEnumerable<byte> Input)
         {
             if (Input == null)
                 return null;
@@ -94,7 +94,7 @@ namespace Orbipacket.Library
         /// </summary>
         /// <param name="Input">A COBS encoded array</param>
         /// <returns>Returns the decoded input</returns>
-        public static IEnumerable<byte> Decode(IEnumerable<byte> Input)
+        public static IEnumerable<byte>? Decode(IEnumerable<byte> Input)
         {
             if (Input == null)
                 return null;

--- a/Orbipacket.Library/Decode.cs
+++ b/Orbipacket.Library/Decode.cs
@@ -19,7 +19,7 @@ namespace Orbipacket
         /// </param>
         public static Packet? GetPacketInformation(byte[] rawpacketData)
         {
-            // 1. Decode COBS
+            // Decode COBS
             byte[] packetData = [.. COBS.Decode(rawpacketData)];
             // Console.WriteLine("Decoded packet data: " + BitConverter.ToString(packetData));
 
@@ -31,7 +31,7 @@ namespace Orbipacket
                 return null;
             }
 
-            // 4. Extract payload length from packet data and  validate it
+            // Extract payload length from packet data and  validate it
             int payloadLength = packetData.Length - PAYLOAD_OFFSET - 2; // Subtract 2 for CRC
 
             if (!ValidatePacket(packetData, payloadLength))

--- a/Orbipacket.Library/PacketBuffer.cs
+++ b/Orbipacket.Library/PacketBuffer.cs
@@ -33,6 +33,17 @@ namespace Orbipacket
                 if (_buffer[i] != Decode._terminationByte)
                     continue; // Start over if not termination byte
 
+                if (i > minPacketSize)
+                {
+                    // We can check if the packet before that termination byte is still valid
+                    byte[] previousPacket = [.. _buffer.GetRange(0, i)];
+                    if (IsCRCValid(previousPacket))
+                    {
+                        _buffer.RemoveRange(0, i);
+                        return previousPacket;
+                    }
+                }
+
                 int j = i + 1;
 
                 // Browse for the next termination byte
@@ -45,7 +56,7 @@ namespace Orbipacket
                 if (j >= _buffer.Count)
                 {
                     // Check if remaining data is a valid packet
-                    byte[] packetData = [.. _buffer.GetRange(i + 1, _buffer.Count - i)];
+                    byte[] packetData = [.. _buffer.GetRange(i + 1, _buffer.Count - i - 1)];
 
                     if (packetData.Length >= minPacketSize && IsCRCValid(packetData))
                     {

--- a/Orbipacket.Library/PacketBuffer.cs
+++ b/Orbipacket.Library/PacketBuffer.cs
@@ -33,17 +33,6 @@ namespace Orbipacket
                 if (_buffer[i] != Decode._terminationByte)
                     continue; // Start over if not termination byte
 
-                if (i > minPacketSize)
-                {
-                    // We can check if the packet before that termination byte is still valid
-                    byte[] previousPacket = [.. _buffer.GetRange(0, i)];
-                    if (IsCRCValid(previousPacket))
-                    {
-                        _buffer.RemoveRange(0, i);
-                        return previousPacket;
-                    }
-                }
-
                 int j = i + 1;
 
                 // Browse for the next termination byte
@@ -55,6 +44,17 @@ namespace Orbipacket
                 // No second termination byte found
                 if (j >= _buffer.Count)
                 {
+                    if (i > minPacketSize && i <= 254)
+                    {
+                        // We can check if the packet before that termination byte is still valid
+                        byte[] previousPacket = [.. _buffer.GetRange(0, i)];
+                        if (IsCRCValid(previousPacket))
+                        {
+                            _buffer.RemoveRange(0, i);
+                            return previousPacket;
+                        }
+                        return null;
+                    }
                     // Check if remaining data is a valid packet
                     byte[] packetData = [.. _buffer.GetRange(i + 1, _buffer.Count - i - 1)];
 

--- a/Orbipacket.Tests/Tests.cs
+++ b/Orbipacket.Tests/Tests.cs
@@ -173,7 +173,7 @@ namespace Orbipacket.Tests
         /// <returns>Encoded packet data, along with valid CRC bytes.</returns>
         /// <exception cref="ArgumentException"></exception>
 
-        private static byte[] CreatePacket(string device)
+        public static byte[] CreatePacket(string device)
         {
             byte control;
             byte[] payload;

--- a/Orbipacket.Tests/Tests.cs
+++ b/Orbipacket.Tests/Tests.cs
@@ -218,8 +218,9 @@ namespace Orbipacket.Tests
             // Append CRC to the packet data
             packetData = [.. packetData, .. crc];
             byte[] encodedDataBeforeNoise = [.. COBS.Encode(packetData)];
+            byte[] dataWithTerminationByte = [.. encodedDataBeforeNoise, .. new byte[] { 0x00 }];
             Console.WriteLine(BitConverter.ToString(encodedDataBeforeNoise));
-            return encodedDataBeforeNoise;
+            return dataWithTerminationByte;
         }
 
         /// <summary>
@@ -236,13 +237,11 @@ namespace Orbipacket.Tests
             byte[] packet2 = CreatePacket("temperature");
             byte[] packet3 = CreatePacket("humidity");
 
-            buffer.Add([0x00]);
             buffer.Add(packet1);
-            buffer.Add([0x00]);
+
             buffer.Add(packet2);
-            buffer.Add([0x00]);
+
             buffer.Add(packet3);
-            buffer.Add([0x00]);
 
             // Loop ExtractFirstValidPacket() until no more valid packets can be extracted
             byte[] extractedPacket;
@@ -277,15 +276,13 @@ namespace Orbipacket.Tests
             Console.WriteLine("Packet 1: " + BitConverter.ToString(packet1));
             Console.WriteLine("Packet 1 (uncomplete):" + BitConverter.ToString(uncompletePacket1));
 
-            buffer.Add([0x00]);
             buffer.Add(uncompletePacket1);
             buffer.Add([0x00]);
             buffer.Add(packet1);
-            buffer.Add([0x00]);
+
             buffer.Add(packet2);
-            buffer.Add([0x00]);
+
             buffer.Add(packet3);
-            buffer.Add([0x00]);
 
             // Loop ExtractFirstValidPacket() until no more valid packets can be extracted
             byte[] extractedPacket;


### PR DESCRIPTION
As said in the issue #1, I wasn't too happy of the runtimes of `ExtractFirstValidPacket()`, especially after implementing the FileProvider, and seeing how slow packets were extracted from the buffer.
To try and compare each method runtime, I benchmarked them to see how drastic the difference actually was:
| Method         | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
|--------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
| ExtractAll_Old | 667.9 ns | 4.96 ns | 4.14 ns |  1.00 | 0.0391 |     656 B |        1.00 |
| ExtractAll_New | 129.4 ns | 1.18 ns | 1.05 ns |  0.19 | 0.0143 |     240 B |        0.37 |

And came down to a staggering 5x improved runtime and less than half of the memory used! I think the previous method, by also analysing the buffer with Array.IndexOf(), turned out to be very slow.
Closes #1 