### PR TITLE
Improve Performance of Packet Buffer

### DIFF
--- a/Orbipacket.Library/Crc.cs
+++ b/Orbipacket.Library/Crc.cs
@@ -27,5 +27,11 @@ namespace Orbipacket.Library
 
             return result;
         }
+
+        public static bool IsCrcValid(byte[] packetData)
+        {
+            byte[] crc = GetCRC(packetData[..^2]);
+            return crc[0] == packetData[^2] && crc[1] == packetData[^1];
+        }
     }
 }

--- a/Orbipacket.Library/PacketBuffer.cs
+++ b/Orbipacket.Library/PacketBuffer.cs
@@ -110,5 +110,37 @@ namespace Orbipacket
             }
             return null;
         }
+
+        public void Clear()
+        {
+            _buffer.Clear();
+            readPosition = 0;
+        }
+
+        public int Length()
+        {
+            return _buffer.Count;
+        }
+
+        public void PrintBuffer()
+        {
+            Console.WriteLine(BitConverter.ToString([.. _buffer]).Replace("-", " "));
+        }
+
+        public byte[] GetBuffer()
+        {
+            return [.. _buffer];
+        }
+
+        public List<byte[]> GetAllPackets()
+        {
+            List<byte[]> packets = [];
+            byte[]? packet;
+            while ((packet = ExtractFirstValidPacket()) != null)
+            {
+                packets.Add(packet);
+            }
+            return packets;
+        }
     }
 }


### PR DESCRIPTION
This PR significantly improves the runtime of packet buffer, with a lot of optimization points, such as:
- Remove the double-COBS-decoding, now only ever doing it twice
- `ExtractFirstValidPacket()` now returns the COBS-decoded and CRC-validated packet, only having the `GetPacketInformation()` to do exactly what the name suggests
- `GetPacketInformation` doesn't decode COBS nor does it validate for CRC, a redundancy that was previously made now fixed
- Created new `DecodeCobsAndValidate()` method inside the Decode class
- Added `readPosition` variable: before we were removing content from the `_buffer` every `ExtractFirstValidPacket()` loop iteration, making the runtime extremely slow and re-allocating memory far more times than we should. Now the buffer is only cleared if the `readPosition` (the index where everything **before** it has already been analyzed) is larger than 0.
- Started using `List<>.IndexOf()` instead of looping through the buffer to find 0x00 bytes (performance shouldn't be affected by this, implementation of both are identical, only improves readability).